### PR TITLE
Update to NCS 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,7 @@ To clone this repository properly use the `west` tool. To install `west` you wil
 Install `west` using `pip3`:
 
 ```
-# Linux
 pip3 install --user -U west
-
-# macOS (Terminal) and Windows (cmd.exe)
-pip3 install -U west
 ```
 
 Once `west` is installed, clone this repository using `west init` and `west update`:
@@ -28,17 +24,14 @@ west update
 
 ## Preparing to Build
 
-If this is your first time working with a Zephyr project on your computer you should follow the [Zephyr getting started guide](https://docs.zephyrproject.org/latest/getting_started/index.html#) to install all the tools.
+If this is your first time working with a Zephyr project on your computer you should follow the [Zephyr getting started guide](https://docs.zephyrproject.org/latest/develop/getting_started/index.html) to install all the tools.
 
-The OOB demo uses zephyr 2.7.99 (2.7.0 dev branch), so GCC 10 is recommended.
-[GNU Arm Embedded Toolchain: 10.3-2021.07](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads) is recommended.
-
-See here to [setup the GNU ARM Embedded tools](https://docs.zephyrproject.org/2.7.0/getting_started/toolchain_3rd_party_x_compilers.html)
+The sample apps use Zephyr 3.1.99, so the [Zephyr SDK v 0.14.2](https://github.com/zephyrproject-rtos/sdk-ng/releases/tag/v0.14.2) is recommended.
 
 ## Building the Firmware
 
 From the directory where you issued the `west init` and `west update` commands you can use the following command to build the firmware:
 
 ```
-west build -b pinnacle_100_dvk -d Pinnacle_100_Sample_Applications/build/[app_name] Pinnacle_100_Sample_Applications/apps/[app_name]
+west build -p auto -b pinnacle_100_dvk -d Pinnacle_100_Sample_Applications/build/[app_name] Pinnacle_100_Sample_Applications/apps/[app_name]
 ```

--- a/west.yml
+++ b/west.yml
@@ -1,5 +1,7 @@
 manifest:
   remotes:
+    - name: CanvasDM
+      url-base: https://github.com/CanvasDM
     - name: LairdCP
       url-base: https://github.com/LairdCP
 
@@ -9,15 +11,32 @@ manifest:
   # These dependencies may need updating if new features are added to the firmware.
   projects:
     - name: Pinnacle_100_Sample_Applications
-      revision: d8faf822cdbdbc2a0d6f87a18cbd6a9bd2e17fac
+      revision: 13d5c7190ca1c1624706153a1124c8c2bb224c0b
       remote: LairdCP
     - name: sdk-nrf
       path: nrf
-      revision: v1.9.0
+      revision: 9a9d1a5c4f5483a7c55b259df69346b702987238
       remote: LairdCP
-      import: true
+      import:
+        # Please keep this list sorted alphabetically.
+        name-blocklist:
+          - Alexa-Gadgets-Embedded-Sample-Code
+          - canopennode
+          - cirrus
+          - civetweb
+          - connectedhomeip
+          - find-my
+          - hal_st
+          - homekit
+          - loramac-node
+          - lvgl
+          - matter
+          - mbed-cloud-client
+          - nrf-802154
+          - openthread
+          - sdk-lc3
     - name: zephyr
-      revision: 9f4d0a24870169fdcd4721a5a4c4fc60e50c7e9c
+      revision: 450dfa9a36f272d56c9bbe3642de3f97ebafc62a
       remote: LairdCP
       import:
         # In addition to the zephyr repository itself, NCS also
@@ -45,16 +64,16 @@ manifest:
           - open-amp
           - openthread
           - segger
-          - tinycbor
           - tinycrypt
-    - name: zephyr_boards
-      path: boards/arm
-      revision: 6429ac0029c476eb621ad5e022d3b5eb0131f219
-      remote: LairdCP
+          - zcbor
     - name: zephyr_lib
       path: modules/lib/laird_connect/zephyr_lib
-      revision: 28df46426a0589d5a2b5ba1def90e5896f92db8d
+      revision: c5db60e1a3fd580671f793144d86089b56dfc600
       remote: LairdCP
+    - name: network_monitor_module
+      path: modules/lib/laird_connect/network_monitor
+      revision: bb7908926648ab07ee69c4308dfd3cf334cc5efe
+      remote: CanvasDM
 
   self:
     path: Pinnacle_100_Sample_Applications_public_manifest


### PR DESCRIPTION
Point to updates to build samples with NCS 2.1.0.

Fix low_power app.
